### PR TITLE
feat: migrate settings to Obsidian 1.13 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "persistent-graph",
-	"version": "0.2.0",
+	"version": "0.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "persistent-graph",
-			"version": "0.2.0",
+			"version": "0.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"process": "^0.11.10"
@@ -17,9 +17,9 @@
 				"@typescript-eslint/parser": "^5.2.0",
 				"builtin-modules": "^3.2.0",
 				"esbuild": "^0.28.0",
-				"obsidian": "^1.12.3",
+				"obsidian": "^1.13.1",
 				"tslib": "2.3.1",
-				"typescript": "4.4.4"
+				"typescript": "^5.9.3"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -1928,9 +1928,9 @@
 			"license": "MIT"
 		},
 		"node_modules/obsidian": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
-			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2370,9 +2370,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -2380,7 +2380,7 @@
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
 		"@typescript-eslint/parser": "^5.2.0",
 		"builtin-modules": "^3.2.0",
 		"esbuild": "^0.28.0",
-		"obsidian": "^1.12.3",
+		"obsidian": "^1.13.1",
 		"tslib": "2.3.1",
-		"typescript": "4.4.4"
+		"typescript": "^5.9.3"
 	},
 	"dependencies": {
 		"process": "^0.11.10"

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,6 +72,7 @@ export class PersistentGraphSettingTab extends PluginSettingTab {
 			{
 				name: 'Enable Auto Save',
 				desc: 'Automatically save graph changes',
+				aliases: ['Auto Save Interval'],
 				render: (setting) => {
 					setting.addToggle((toggle) =>
 						toggle

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,18 +72,41 @@ export class PersistentGraphSettingTab extends PluginSettingTab {
 			{
 				name: 'Enable Auto Save',
 				desc: 'Automatically save graph changes',
-				control: { type: 'toggle', key: 'enableAutoSave' },
+				render: (setting) => {
+					setting.addToggle((toggle) =>
+						toggle
+							.setValue(this.plugin.settings.enableAutoSave)
+							.onChange(async (value) => {
+								this.plugin.settings.enableAutoSave = value;
+								await this.plugin.saveSettings();
+								if (value) {
+									this.plugin.graphManager.startAutoSave();
+								} else {
+									this.plugin.graphManager.stopAutoSave();
+								}
+								this.update();
+							})
+					);
+				},
 			},
 			{
 				name: 'Auto Save Interval',
 				desc: 'Interval in minutes to auto save the graph',
 				visible: () => this.plugin.settings.enableAutoSave,
-				control: {
-					type: 'slider',
-					key: 'autoSaveIntervalMinutes',
-					min: 1,
-					max: 60,
-					step: 1,
+				render: (setting) => {
+					setting.addSlider((slider) =>
+						slider
+							.setLimits(1, 60, 1)
+							.setValue(this.plugin.settings.autoSaveIntervalMinutes)
+							.setDynamicTooltip()
+							.onChange(async (value) => {
+								this.plugin.settings.autoSaveIntervalMinutes = value;
+								await this.plugin.saveSettings();
+								if (this.plugin.settings.enableAutoSave) {
+									this.plugin.graphManager.startAutoSave();
+								}
+							})
+					);
 				},
 			},
 			{

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,5 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
+import { App, PluginSettingTab, requireApiVersion, Setting } from 'obsidian';
+import type { SettingDefinitionItem } from 'obsidian';
 import {GraphData, NodePosition} from "./types";
 import PersistentGraphPlugin from "./main";
 
@@ -40,6 +41,77 @@ export class PersistentGraphSettingTab extends PluginSettingTab {
 	constructor(app: App, plugin: PersistentGraphPlugin) {
 		super(app, plugin);
 		this.plugin = plugin;
+	}
+
+	getSettingDefinitions(): SettingDefinitionItem<keyof PersistentGraphSettings>[] {
+		if (!requireApiVersion('1.13.0')) {
+			return [];
+		}
+
+		return [
+			{
+				name: 'Automatically restore node positions',
+				desc: 'Restore node positions every time a graph view is opened',
+				control: { type: 'toggle', key: 'automaticallyRestoreNodePositions' },
+			},
+			{
+				name: 'Save the filtered configuration',
+				desc: 'Filters, Groups, Display, Forces',
+				control: { type: 'toggle', key: 'enableSaveOptions' },
+			},
+			{
+				name: 'Save graph layout separately for each workspace',
+				desc: 'Use workspace name as storage key',
+				control: { type: 'toggle', key: 'enableWorkspaces' },
+			},
+			{
+				name: 'Show notification on save',
+				desc: 'Display a notice when saving the graph',
+				control: { type: 'toggle', key: 'showSaveNotification' },
+			},
+			{
+				name: 'Enable Auto Save',
+				desc: 'Automatically save graph changes',
+				control: { type: 'toggle', key: 'enableAutoSave' },
+			},
+			{
+				name: 'Auto Save Interval',
+				desc: 'Interval in minutes to auto save the graph',
+				visible: () => this.plugin.settings.enableAutoSave,
+				control: {
+					type: 'slider',
+					key: 'autoSaveIntervalMinutes',
+					min: 1,
+					max: 60,
+					step: 1,
+				},
+			},
+			{
+				name: 'Enable graph simulation commands',
+				desc: 'Controls whether "Run graph simulation" and "Stop graph simulation" commands are available.\n Requires restart.',
+				control: { type: 'toggle', key: 'enableGraphSimulationCommands' },
+			},
+		];
+	}
+
+	async setControlValue(key: string, value: unknown): Promise<void> {
+		if (!(key in this.plugin.settings)) {
+			return;
+		}
+
+		Reflect.set(this.plugin.settings, key, value);
+		await this.plugin.saveSettings();
+
+		if (key === 'enableAutoSave') {
+			if (value) {
+				this.plugin.graphManager.startAutoSave();
+			} else {
+				this.plugin.graphManager.stopAutoSave();
+			}
+			this.update();
+		} else if (key === 'autoSaveIntervalMinutes' && this.plugin.settings.enableAutoSave) {
+			this.plugin.graphManager.startAutoSave();
+		}
 	}
 
 	display(): void {


### PR DESCRIPTION
Adds `getSettingDefinitions()` for Obsidian 1.13 while retaining the legacy `display()` fallback and existing validation, persistence, and graph-update behavior. Obsidian and TypeScript dependencies are updated for the 1.13 and CodeMirror declarations.

`npm run check` and the production build pass. The repository does not define a lint script.