### PR TITLE
fix: reliably restore graph positions after simulation cools

### DIFF
--- a/src/graphManager.ts
+++ b/src/graphManager.ts
@@ -110,7 +110,18 @@ export class GraphManager {
 			});
 		});
 
-		// wait for a render, then unlock nodes
+		// Obsidian's graph worker ignores forceNode updates after the simulation has
+		// cooled down unless it is explicitly woken.  A very small alpha is enough
+		// to render the fixed coordinates without starting a fresh layout run.
+		graphLeaf.view.renderer.worker.postMessage({
+			run: true,
+			alpha: 0.002,
+			alphaTarget: 0,
+		});
+
+		// A newly-created graph worker can still be running at full alpha. Keep the
+		// restored nodes fixed until that native simulation has cooled (about five
+		// seconds), then release all nodes that were not deliberately pinned.
 		setTimeout(async () => {
 			for (let i = 0; i < nodePositions.length; i++) {
 				const node = nodePositions[i];
@@ -133,7 +144,7 @@ export class GraphManager {
 				this.settings.timesShowedRestoredNotification++;
 				await this.plugin.saveSettings();
 			}
-		}, 600);
+		}, 7000);
 	}
 
 	freedWorkspacesData() {


### PR DESCRIPTION
## Summary

- wake Obsidian's graph worker after applying saved node coordinates
- keep restored nodes fixed until a newly-created simulation has had time to cool
- continue releasing every node that is not deliberately pinned

## Problem

`restoreGraphData()` currently sends `forceNode` messages and releases the nodes 600 ms later. This has two failure modes:

1. If the graph simulation has already cooled, `forceNode` updates `fx`/`fy` inside the worker but does not schedule another simulation tick. A manual restore can therefore appear to do nothing.
2. During a fresh graph build, the native simulation can still have substantial energy when the nodes are released after 600 ms, so the restored layout immediately drifts apart again.

The pre-revival implementation explicitly woke the worker with a `run` message after applying the coordinates. That redraw step was lost during the refactor merged in #30.

This is related to the restore timing discussed in #5. It may also contribute to some historical reports where restoring positions appeared ineffective, although this PR intentionally does not claim to fix unrelated startup leaf-selection issues.

## Implementation

After setting the saved coordinates, the patch posts:

```ts
{
  run: true,
  alpha: 0.002,
  alphaTarget: 0,
}
```

The small alpha wakes a cooled worker without starting a fresh high-energy layout run.

Restored nodes remain fixed for 7 seconds instead of 600 ms. In Obsidian 1.13.4, the graph worker starts at alpha 1, runs at 60 Hz, and uses the standard decay to alpha 0.001 over 300 ticks—about 5 seconds. The additional 2 seconds are a conservative margin for worker startup, message delivery, and rendering on a large graph. A worker woken at alpha 0.002 cools in roughly 31 ticks (about 0.5 seconds), so the longer hold mainly protects the startup/full-rebuild path.

After the timeout, the existing logic releases all nodes that are not explicitly pinned. New files and links can therefore still participate in future simulation runs.

## Reproduction and runtime verification

Environment:

- Obsidian 1.13.4 on macOS
- Persistent Graph 0.3.2
- 381 rendered nodes: 319 file nodes plus 62 virtual folder nodes added by Folders to Graph
- Auto Save disabled

Observed with unmodified 0.3.2:

- a full graph reload rebuilt the layout and the restored coordinates did not survive the active simulation
- after the simulation cooled, pressing **Restore graph positions** produced no visible restoration

Observed with this patch:

- after replacing the plugin build and restoring the saved data while Obsidian was closed, automatic restoration on the next launch recovered the saved layout
- the same `restoreGraphData()` implementation is used by both automatic and manual restore actions

## Checks

Passed:

```text
npx --yes -p typescript@5.9.2 tsc --noEmit --skipLibCheck
npm run build
node --check main.js
git diff --check
```

The repository's current `npm run check` uses TypeScript 4.4 and fails on unmodified `master` while parsing newer Node/CodeMirror declaration syntax. The source change passes with TypeScript 5.9.2; the open settings migration in #32 independently updates those dependencies.

I am happy to adjust the timeout or extract the worker parameters into named constants if the maintainer prefers a different trade-off.